### PR TITLE
Update examples IP and port addresses to conform to embedded usage mode

### DIFF
--- a/Networking/Cisco/bgp_multi_protocol.cf
+++ b/Networking/Cisco/bgp_multi_protocol.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/bgp_vrf.cf
+++ b/Networking/Cisco/bgp_vrf.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/hostname.cf
+++ b/Networking/Cisco/hostname.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/interface.cf
+++ b/Networking/Cisco/interface.cf
@@ -3,8 +3,8 @@ import ciscoxr
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/interface_qos.cf
+++ b/Networking/Cisco/interface_qos.cf
@@ -4,8 +4,8 @@ import ciscoxr_services::interface as cs_int
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/interface_vrf.cf
+++ b/Networking/Cisco/interface_vrf.cf
@@ -4,8 +4,8 @@ import ciscoxr_services as cs
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/ip_address.cf
+++ b/Networking/Cisco/ip_address.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/l2vpn.cf
+++ b/Networking/Cisco/l2vpn.cf
@@ -4,8 +4,8 @@ import ciscoxr_services as cs
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/ntp.cf
+++ b/Networking/Cisco/ntp.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/policy_map.cf
+++ b/Networking/Cisco/policy_map.cf
@@ -4,8 +4,8 @@ import ciscoxr_services::policy_map as pm
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/static_route.cf
+++ b/Networking/Cisco/static_route.cf
@@ -4,8 +4,8 @@ import ciscoxr::staticroute as sr
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/static_route_vrf.cf
+++ b/Networking/Cisco/static_route_vrf.cf
@@ -4,8 +4,8 @@ import ciscoxr::staticroute as sr
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/sub_interface.cf
+++ b/Networking/Cisco/sub_interface.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/timezone.cf
+++ b/Networking/Cisco/timezone.cf
@@ -3,8 +3,8 @@ import ciscoxr as c
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Cisco/vrf.cf
+++ b/Networking/Cisco/vrf.cf
@@ -4,8 +4,8 @@ import ciscoxr_services as cs
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
-port = 21830             # Device NETCONF port
+mgmt_ip = "10.11.12.11"  # Device management IP address
+port = 830               # Device NETCONF port
 username = "admin"       # Device username
 password = "admin"       # Device password
 

--- a/Networking/Juniper/bgp_vrf.cf
+++ b/Networking/Juniper/bgp_vrf.cf
@@ -5,8 +5,8 @@ import juniper_services as js
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/bridge_domains.cf
+++ b/Networking/Juniper/bridge_domains.cf
@@ -6,8 +6,8 @@ import juniper_services::firewall as fw
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/ethernet_switching.cf
+++ b/Networking/Juniper/ethernet_switching.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/evpn_vpws.cf
+++ b/Networking/Juniper/evpn_vpws.cf
@@ -5,8 +5,8 @@ import juniper_services as js
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/evpn_vxlan_routing_instances.cf
+++ b/Networking/Juniper/evpn_vxlan_routing_instances.cf
@@ -5,8 +5,8 @@ import juniper_services as js
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/firewall.cf
+++ b/Networking/Juniper/firewall.cf
@@ -7,8 +7,8 @@ import juniper_services::firewall as fw
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/interface.cf
+++ b/Networking/Juniper/interface.cf
@@ -3,7 +3,7 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
+mgmt_ip = "10.11.12.21"  # Device management IP address
 port = 22830             # Device NETCONF port
 username = "admin"       # Device username
 password = "admin@123"   # Device password
@@ -43,7 +43,7 @@ address = j::Address_inet(          # Instantiate the IPv4 address entity
 # Set speed, MTU and auto-negotiation for interface
 j::Interface(                           # Instantiate interface entity
     device=router,                      # router is the instance we defined above
-    interface_name="ge-0/0/20",         # Name of the intended interface
+    interface_name="ge-0/0/2",          # Name of the intended interface
     speed="100m",                       # Specify speed
     mtu=9000,                           # Specify MTU
     gigether_opt_auto_neg=true,         # Enable auto negotiation

--- a/Networking/Juniper/irb.cf
+++ b/Networking/Juniper/irb.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/l2_circuit.cf
+++ b/Networking/Juniper/l2_circuit.cf
@@ -5,8 +5,8 @@ import juniper_services as js
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/link_aggregation.cf
+++ b/Networking/Juniper/link_aggregation.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/main.cf
+++ b/Networking/Juniper/main.cf
@@ -4,7 +4,7 @@ import juniper
 # You can define the device information here for easier management
 hostname = "router"
 mgmt_ip = "10.11.12.21"
-port = 22830
+port = 830
 username = "admin"
 password = "admin@123"
 

--- a/Networking/Juniper/main.cf
+++ b/Networking/Juniper/main.cf
@@ -2,19 +2,19 @@
 import juniper
 
 # You can define the device information here for easier management
-HOSTNAME = "router"
-MGMT_IP = "192.168.2.20"
-PORT = 22830
-USERNAME = "admin"
-PASSWORD = "admin"
+hostname = "router"
+mgmt_ip = "10.11.12.21"
+port = 22830
+username = "admin"
+password = "admin@123"
 
 # Construct the router instance using the imported module name and feed it the information above
 router = juniper::Device(
-    name=HOSTNAME,
-    mgmt_ip=MGMT_IP,
-    port=PORT,
-    username=USERNAME,
-    password=PASSWORD,
+    name=hostname,
+    mgmt_ip=mgmt_ip,
+    port=port,
+    username=username,
+    password=password,
 )
 
 # Define an interface and change its administrative state to "DOWN"

--- a/Networking/Juniper/policer.cf
+++ b/Networking/Juniper/policer.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/policy_options.cf
+++ b/Networking/Juniper/policy_options.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/protocols_evpn.cf
+++ b/Networking/Juniper/protocols_evpn.cf
@@ -5,8 +5,8 @@ import juniper_services as js
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/rpf_filter.cf
+++ b/Networking/Juniper/rpf_filter.cf
@@ -3,8 +3,8 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.21"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin@123"   # Device password
 

--- a/Networking/Juniper/vlan_QFX.cf
+++ b/Networking/Juniper/vlan_QFX.cf
@@ -3,7 +3,7 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
+mgmt_ip = "10.11.12.21" # Device management IP address
 port = 22830             # Device NETCONF port
 username = "admin"       # Device username
 password = "admin@123"   # Device password

--- a/Networking/Juniper/vxlan_QFX.cf
+++ b/Networking/Juniper/vxlan_QFX.cf
@@ -3,7 +3,7 @@ import juniper as j
 
 # You can define the device information here for easier management
 hostname = "router"      # Device hostname
-mgmt_ip = "192.168.2.20" # Device management IP address
+mgmt_ip = "10.11.12.21" # Device management IP address
 port = 22830             # Device NETCONF port
 username = "admin"       # Device username
 password = "admin@123"   # Device password

--- a/Networking/Nokia/bgp.cf
+++ b/Networking/Nokia/bgp.cf
@@ -4,8 +4,8 @@ import nokiasr::router
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/epipe.cf
+++ b/Networking/Nokia/epipe.cf
@@ -5,8 +5,8 @@ import nokiasr_service_epipe
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/eth_cfm.cf
+++ b/Networking/Nokia/eth_cfm.cf
@@ -4,8 +4,8 @@ import nokiasr_eth_cfm
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/eth_cfm_client.cf
+++ b/Networking/Nokia/eth_cfm_client.cf
@@ -4,8 +4,8 @@ import nokiasr_services
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/etherhet_segment.cf
+++ b/Networking/Nokia/etherhet_segment.cf
@@ -4,8 +4,8 @@ import nokiasr_services
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/policy_options.cf
+++ b/Networking/Nokia/policy_options.cf
@@ -8,8 +8,8 @@ import nokiasr_policy_options::policy_statement::entry::from
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/snmp.cf
+++ b/Networking/Nokia/snmp.cf
@@ -3,8 +3,8 @@ import nokiasr
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/tacacs.cf
+++ b/Networking/Nokia/tacacs.cf
@@ -3,8 +3,8 @@ import nokiasr
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 

--- a/Networking/Nokia/vprn.cf
+++ b/Networking/Nokia/vprn.cf
@@ -8,8 +8,8 @@ import nokiasr_service_vprn::interface::sap
 
 # You can define the device information here for easier management
 hostname="router"      # Device hostname
-mgmt_ip="192.168.2.20" # Device management IP address
-port=22830             # Device NETCONF port
+mgmt_ip="10.11.12.31"  # Device management IP address
+port=830               # Device NETCONF port
 username="admin"       # Device username
 password="admin"       # Device password
 


### PR DESCRIPTION
# Summary

Updates all routers' IP and port addresses to conform to embedded usage mode. In embedded mode, we are not using containerlab's `iptables` NAT tricks, and deploying/exporting the examples will cause socket failures.