### PR TITLE
Add comanaged for MTU config of Juniper

### DIFF
--- a/Networking/Juniper/interface.cf
+++ b/Networking/Juniper/interface.cf
@@ -47,4 +47,5 @@ j::Interface(                           # Instantiate interface entity
     speed="100m",                       # Specify speed
     mtu=9000,                           # Specify MTU
     gigether_opt_auto_neg=true,         # Enable auto negotiation
+    comanaged=false,                    # Only Inmanta manages the configuration
 )


### PR DESCRIPTION
# Summary

Adds `comanaged` to false for MTU config of Juniper example.