### PR TITLE
Add auto_agent to interface example and main.cf

### DIFF
--- a/Networking/Cisco/interface.cf
+++ b/Networking/Cisco/interface.cf
@@ -15,6 +15,7 @@ router = ciscoxr::Device(
     port=port,
     username=username,
     password=password,
+    auto_agent=true
 )
 
 # Define an interface and change its administrative state to "DOWN"

--- a/Networking/Cisco/main.cf
+++ b/Networking/Cisco/main.cf
@@ -1,0 +1,1 @@
+import ciscoxr


### PR DESCRIPTION
# Summary

Adds auto_agent to `interface` example and brings back `main.cf`.