### PR TITLE
Pin srlinux containers to version 22.6.4

### DIFF
--- a/Networking/SR Linux/ci/do_test_deployment_and_verify.sh
+++ b/Networking/SR Linux/ci/do_test_deployment_and_verify.sh
@@ -26,13 +26,21 @@ inmanta -vvv export -f main.cf
 inmanta -vvv export -f interfaces.cf
 
 while inmanta-cli  --host 172.30.0.3  version list -e SR_Linux | grep deploying; do sleep 1; done
-inmanta-cli  --host 172.30.0.3  version list -e SR_Linux | grep success
+
+if [ -z "$(inmanta-cli --host 172.30.0.3 version list -e SR_Linux |grep '^|' |cut -d '|' -f 3,8 |grep '2' |grep -i success)" ]; then
+   echo "interfaces.cf was not deployed successfully"
+   exit 1
+fi
 
 # test ospf
 inmanta -vvv export -f ospf.cf
 
 while inmanta-cli  --host 172.30.0.3  version list -e SR_Linux | grep deploying; do sleep 1; done
-inmanta-cli  --host 172.30.0.3  version list -e SR_Linux | grep success
+
+if [ -z "$(inmanta-cli --host 172.30.0.3 version list -e SR_Linux |grep '^|' |cut -d '|' -f 3,8 |grep '3' |grep -i success)" ]; then
+   echo "ospf.cf was not deployed successfully"
+   exit 1
+fi
 
 # fetch logs
 sudo docker logs clab-srlinux-inmanta-server >server.log

--- a/Networking/SR Linux/containerlab/topology.yml
+++ b/Networking/SR Linux/containerlab/topology.yml
@@ -6,7 +6,7 @@ mgmt:
 topology:
   kinds:
     srl:
-      image: ghcr.io/nokia/srlinux
+      image: ghcr.io/nokia/srlinux:22.6.4-90
   nodes:
     inmanta-server:
       kind: linux

--- a/Networking/SR Linux/containerlab/topology.yml
+++ b/Networking/SR Linux/containerlab/topology.yml
@@ -6,7 +6,7 @@ mgmt:
 topology:
   kinds:
     srl:
-      image: ghcr.io/nokia/srlinux:22.6.4-90
+      image: ghcr.io/nokia/srlinux:22.6.4
   nodes:
     inmanta-server:
       kind: linux


### PR DESCRIPTION
The latest version of the srlinux container (22.11.1) doesn't accept the credentials username=admin and password=admin anymore. But it does offer support for authentication using SSH-keys. I still need to figure out the details. This PR is a quickfix to make sure that the quickstart works again. I will create a follow up PR that fixes this properly. This PR applies the following changes:

* Pin the srlinux container to the previous version that accepts username-password authentication using.
* Make the `do_test_deployment_and_verify.sh` script fail when the deployment of a resource fails.