### PR TITLE
Compatibility with containerlab 0.39

### DIFF
--- a/Networking/SR Linux/ci/Jenkinsfile
+++ b/Networking/SR Linux/ci/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                         sh '''
                             # Cleanup before starting
                             cd "Networking/SR Linux"
-                            sudo clab destroy --cleanup -t containerlab/topology.yml
+                            sudo clab destroy --cleanup -t containerlab/topology.yml | true
                             # Workaround for: https://github.com/srl-labs/containerlab/issues/1306
                             sudo docker network rm -f inmanta_mgmt
                             rm -f *.log

--- a/Networking/SR Linux/ci/Jenkinsfile
+++ b/Networking/SR Linux/ci/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
                         sh '''
                             # Cleanup before starting
                             cd "Networking/SR Linux"
-                            sudo clab destroy --cleanup -t containerlab/topology.yml | true
+                            sudo clab destroy --cleanup -t containerlab/topology.yml || true
                             # Workaround for: https://github.com/srl-labs/containerlab/issues/1306
                             sudo docker network rm -f inmanta_mgmt
                             rm -f *.log

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -71,14 +71,16 @@ def convert_iso_version_to_docker_image_url(String isoProductVersion) {
 
 /**
 * Returns the script that tears down the lab environment.
+*
+* @param strict: If false, allow the cleanup to fail, e.g. because the containers do not yet exist.
 */
-def get_tear_down_script() {
-   return '''
-       cd "${WORKSPACE}/lsm-srlinux"
-       sudo clab destroy --cleanup -t containerlab/topology.yml
+def get_tear_down_script(boolean strict = true) {
+   return """
+       cd '${env.WORKSPACE}/lsm-srlinux'
+       sudo clab destroy --cleanup -t containerlab/topology.yml ${strict ? '' : '| true'}
        # Workaround for: https://github.com/srl-labs/containerlab/issues/1306
        sudo docker network rm -f inmanta_mgmt
-   ''' 
+   """
 }
 
 
@@ -121,7 +123,7 @@ pipeline {
                 }
                 script {
                     // Cleanup before starting
-                    sh(script: get_tear_down_script())
+                    sh(script: get_tear_down_script(false))
                 }
             }
         }

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -77,7 +77,7 @@ def convert_iso_version_to_docker_image_url(String isoProductVersion) {
 def get_tear_down_script(boolean strict = true) {
    return """
        cd '${env.WORKSPACE}/lsm-srlinux'
-       sudo clab destroy --cleanup -t containerlab/topology.yml ${strict ? '' : '| true'}
+       sudo clab destroy --cleanup -t containerlab/topology.yml ${strict ? '' : '|| true'}
        # Workaround for: https://github.com/srl-labs/containerlab/issues/1306
        sudo docker network rm -f inmanta_mgmt
    """


### PR DESCRIPTION
Containerlab released [0.39](https://github.com/srl-labs/containerlab/releases/tag/v0.39.0) yesterday. `containerlab destroy` now results in an error when (one of the?) containers is (are?) not found. (srl-labs/containerlab#1297?). This PR makes sure the pre-test cleanup doesn't fail on that.