### PR TITLE
Ensure clean workspace before run quickstart-lsm Jenkinsfile

### DIFF
--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -101,11 +101,14 @@ pipeline {
 
     options {
         disableConcurrentBuilds()
+        skipDefaultCheckout()
     }
 
     stages {
         stage('Cleanup') {
             steps {
+                deleteDir()
+                checkout scm
                 withCredentials([
                     file(credentialsId: 'JENKINS_JWE', variable: 'ENTITLEMENTS_FILE'),
                     file(credentialsId: 'JENKINS_LICENSE', variable: 'LICENSE_KEY_FILE'),


### PR DESCRIPTION
The `quickstart-lsm` Jenkins job regularly fails with the exception.

```
+ cd /home/jenkins/workspace/tion-tests_quickstart-lsm_master/lsm-srlinux/containerlab
+ mkdir resources
mkdir: cannot create directory ‘resources’: File exists
```

This PR ensures that the workspace is always cleaned up before starting a new build.