### PR TITLE
Set the config.agent-get-resource-backoff config option

### DIFF
--- a/Networking/SR Linux/containerlab/inmanta.cfg
+++ b/Networking/SR Linux/containerlab/inmanta.cfg
@@ -26,6 +26,8 @@ agent_repair_interval = 86400
 # The splaytime added to the agent_repair_interval. Set this to 0 to disable splaytime
 agent_repair_splay_time = 600
 
+agent-get-resource-backoff=3
+
 [database]
 # The hostname of the database server
 host = 172.30.0.2


### PR DESCRIPTION
* Force the `config.agent-get-resource-backoff` config option to `3`.
* Improve the logging of the `do_test_deployment_and_verify.sh` script when the deployment fails.