### PR TITLE
Fix version conflict in Jenkins job for lsm quickstart

### DIFF
--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
     agent any
 
     parameters {
-        string(name: 'version', defaultValue: '7dev', description: 'Run the lsm quickstart against the specified version of ISO product. The version can be of format 6.1.1rc20230217144359, 6.1.1rc, 6.1.1, 6 or 6dev.')
+        string(name: 'version', defaultValue: '7', description: 'Run the lsm quickstart against the specified version of ISO product. The version can be of format 6.1.1rc20230217144359, 6.1.1rc, 6.1.1, 6 or 6dev.')
     }
 
     environment {
@@ -157,7 +157,7 @@ pipeline {
                             pip install -U pip
                             if [[ ${version} == *dev ]]; then
                                 major_version=${version::-3}
-                                pip install "inmanta-core[pytest-inmanta-extensions]" "inmanta-service-orchestrator~=${major_version}.0.dev"
+                                pip install --pre "inmanta-core[pytest-inmanta-extensions]" "inmanta-service-orchestrator~=${major_version}.0.dev"
                             else
                                 pip install "inmanta-core[pytest-inmanta-extensions]" "inmanta-service-orchestrator==${version}"
                             fi

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -88,7 +88,7 @@ pipeline {
     agent any
 
     parameters {
-        string(name: 'version', defaultValue: '7', description: 'Run the lsm quickstart against the specified version of ISO product. The version can be of format 6.1.1rc20230217144359, 6.1.1rc, 6.1.1, 6 or 6dev.')
+        string(name: 'version', defaultValue: '6', description: 'Run the lsm quickstart against the specified version of ISO product. The version can be of format 6.1.1rc20230217144359, 6.1.1rc, 6.1.1, 6 or 6dev.')
     }
 
     environment {


### PR DESCRIPTION
This PR fixes two issues:

* The `--pre` flag was missing when running against a development release. This resulted in a version conflict because pip was trying to match a stable version of `inmanta-core` against a dev version of `inmanta-service-orchestrator`.
* This job was running against an ISO7 dev release by default, while we actually want to verify whether the stable releases are working correctly, because those are used by our end-users. I changed it to run against the latest stable release of iso6 by default. I will create another ticket to make sure this jobs takes into account add stable iso versions.