### PR TITLE
Issues/infra tickets 180 quickstart lsm pip install

### DIFF
--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -161,7 +161,7 @@ pipeline {
                             fi
                             # install inmanta-dev-dependencies[extension] rather than pytest-inmanta-extensions directly to
                             # help pip find matching candidates (see inmanta/infra-tickets#180)
-                            pip install "inmanta-service-orchestrator${constraint} inmanta-dev-dependencies[extension]"
+                            pip install "inmanta-service-orchestrator${constraint}" 'inmanta-dev-dependencies[extension]'
 
                             sudo clab deploy -t containerlab/topology.yml --reconfigure
                             python -u ci/do_test_deployment_and_verify.py

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -163,7 +163,7 @@ pipeline {
                             # install inmanta-dev-dependencies[extension] rather than pytest-inmanta-extensions directly to
                             # help pip find matching candidates (see inmanta/infra-tickets#180)
                             # TODO: does the >=0.dev make sense for stable iso as well?
-                            pip install "inmanta-service-orchestrator${constraint}" inmanta-dev-dependencies[extension] 'inmanta-core>=0.dev'
+                            pip install "inmanta-service-orchestrator${constraint}" inmanta-dev-dependencies[extension]
 
                             sudo clab deploy -t containerlab/topology.yml --reconfigure
                             python -u ci/do_test_deployment_and_verify.py

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -161,7 +161,8 @@ pipeline {
                             fi
                             # install inmanta-dev-dependencies[extension] rather than pytest-inmanta-extensions directly to
                             # help pip find matching candidates (see inmanta/infra-tickets#180)
-                            pip install "inmanta-service-orchestrator${constraint}" 'inmanta-dev-dependencies[extension]'
+                            # TODO: does the >=0.dev make sense for stable iso as well?
+                            pip install "inmanta-service-orchestrator${constraint}" inmanta-dev-dependencies[extension] 'inmanta-core>=0.dev'
 
                             sudo clab deploy -t containerlab/topology.yml --reconfigure
                             python -u ci/do_test_deployment_and_verify.py

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -150,12 +150,10 @@ pipeline {
                             sudo docker pull ghcr.io/nokia/srlinux:latest
 
                             # Create python environment
-                            # TODO: use irt to determine version?
+                            # TODO: use irt to determine version? -> same for OSS
                             python3.9 -m venv venv
                             source "venv/bin/activate"
-                            # TODO: remove this
-                            git clone https://github.com/sanderr/pip.git -b issue/11924-requirements-on-extras
-                            pip install -e ./pip/
+                            pip install -U pip
                             if [[ ${version} == *dev ]]; then
                                 constraint="~=${version::-3}.0.dev"
                             else

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -150,7 +150,8 @@ pipeline {
                             sudo docker pull ghcr.io/nokia/srlinux:latest
 
                             # Create python environment
-                            python3 -m venv venv
+                            # TODO: use irt to determine version?
+                            python3.9 -m venv venv
                             source "venv/bin/activate"
                             pip install -U pip
                             if [[ ${version} == *dev ]]; then

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -150,8 +150,7 @@ pipeline {
                             sudo docker pull ghcr.io/nokia/srlinux:latest
 
                             # Create python environment
-                            # TODO: use irt to determine version? -> same for OSS
-                            python3.9 -m venv venv
+                            python3 -m venv venv
                             source "venv/bin/activate"
                             pip install -U pip
                             if [[ ${version} == *dev ]]; then

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -153,7 +153,9 @@ pipeline {
                             # TODO: use irt to determine version?
                             python3.9 -m venv venv
                             source "venv/bin/activate"
-                            pip install -U pip
+                            # TODO: remove this
+                            git clone https://github.com/sanderr/pip.git -b issue/11924-requirements-on-extras
+                            pip install -e ./pip/
                             if [[ ${version} == *dev ]]; then
                                 constraint="~=${version::-3}.0.dev"
                             else

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -154,11 +154,14 @@ pipeline {
                             source "venv/bin/activate"
                             pip install -U pip
                             if [[ ${version} == *dev ]]; then
-                                major_version=${version::-3}
-                                pip install --pre "inmanta-core[pytest-inmanta-extensions]" "inmanta-service-orchestrator~=${major_version}.0.dev"
+                                constraint="~=${version::-3}.0.dev"
                             else
-                                pip install "inmanta-core[pytest-inmanta-extensions]" "inmanta-service-orchestrator==${version}"
+                                # allow nothing to float by adding fourth floating digit
+                                constraint="==${version}"
                             fi
+                            # install inmanta-dev-dependencies[extension] rather than pytest-inmanta-extensions directly to
+                            # help pip find matching candidates (see inmanta/infra-tickets#180)
+                            pip install "inmanta-service-orchestrator${constraint} inmanta-dev-dependencies[extension]"
 
                             sudo clab deploy -t containerlab/topology.yml --reconfigure
                             python -u ci/do_test_deployment_and_verify.py

--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -162,7 +162,6 @@ pipeline {
                             fi
                             # install inmanta-dev-dependencies[extension] rather than pytest-inmanta-extensions directly to
                             # help pip find matching candidates (see inmanta/infra-tickets#180)
-                            # TODO: does the >=0.dev make sense for stable iso as well?
                             pip install "inmanta-service-orchestrator${constraint}" inmanta-dev-dependencies[extension]
 
                             sudo clab deploy -t containerlab/topology.yml --reconfigure


### PR DESCRIPTION
Updated pip install command to better guide pip to avoid long backtracking. Implemented option 1 as described in [the ticket](https://github.com/inmanta/infra-tickets/issues/180#issuecomment-1715587389).

Closes inmanta/infra-tickets#180