### PR TITLE
Remove LSM contraint

### DIFF
--- a/lsm-testing/requirements.txt
+++ b/lsm-testing/requirements.txt
@@ -1,4 +1,4 @@
 inmanta-module-std==5.2.2
-inmanta-module-lsm==2.28.11
+inmanta-module-lsm
 inmanta-module-config==0.3.0
 inmanta-module-fs==1.0.0

--- a/lsm-testing/requirements.txt
+++ b/lsm-testing/requirements.txt
@@ -1,4 +1,6 @@
 inmanta-module-std==5.2.2
+# `inmanta-module-lsm` should also be pinned but the constraint on LSM has been removed, given that dependabot is not
+# able to fetch the latest version (not available on pypi)
 inmanta-module-lsm
 inmanta-module-config==0.3.0
 inmanta-module-fs==1.0.0


### PR DESCRIPTION
The constraint on LSM has been removed, given that dependabot is not able to fetch the latest version