### PR TITLE
tentative pr to adapt to new generic module pipeline

### DIFF
--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -11,4 +11,6 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
+# We can't rely on the generic module ci to find out the correct python binary since this
+# module doesn't have its own repo. Pass it as a config option instead:
 python_binary: python3

--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -11,3 +11,4 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
+python_binary: python3


### PR DESCRIPTION
This PR is an attempt to fix the ci for this dependabot [PR](https://github.com/inmanta/examples/pull/125)

This [change](https://github.com/inmanta/irt/commit/01e9c99a6506bbace926aa491f0be7af95e9cb88) to the generic module pipeline removed the default value for the `python_binary` which we were relying on for the examples tests.

This PR passes this default via a config option

Sanity check [PR](https://github.com/inmanta/examples/pull/127) that reproduces the issue.
