### PR TITLE
fix 'dev' tag support for lsm-srlinux ci

### DIFF
--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -33,12 +33,16 @@ def update_project_yml(String isoProductVersion, String token) {
 */
 def update_topology(String isoProductVersion) {
     def major
-    try {
-        // do not store Matcher object in variable!
-        // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
-        major = (isoProductVersion =~ /(\d+).*/)[0][1]
-    } catch (IndexOutOfBoundsException) {
-        error("Invalid version specifier")
+    if (isoProductVersion == "dev") {
+        major = "latest"
+    } else {
+        try {
+            // do not store Matcher object in variable!
+            // see https://www.jenkins.io/doc/book/pipeline/pipeline-best-practices/#avoiding-notserializableexception
+            major = (isoProductVersion =~ /(\d+).*/)[0][1]
+        } catch (IndexOutOfBoundsException) {
+            error("Invalid version specifier")
+        }
     }
     def dockerImageUrl = convert_iso_version_to_docker_image_url(isoProductVersion)
     def topology_file = "${env.WORKSPACE}/lsm-srlinux/containerlab/topology.yml"


### PR DESCRIPTION
#184 added `-c https://docs.inmanta.com...`, but it didn't take into account that the default is to run the job with iso version `dev`. This PR fixes that by translating `dev` to `latest`, because https://docs.inmanta.com/inmanta-service-orchestrator-dev/latest redirects to the latest dev docs.