### PR TITLE
Set iso_version to latest on examples/lsm-testing

### DIFF
--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -12,6 +12,3 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
-# iso_version derives the correct Python version from the ISO compatibility.json, avoiding
-# reliance on the Jenkins runner's default python3 binary.
-iso_version: latest

--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -12,6 +12,4 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
-# We can't rely on the generic module ci to find out the correct python binary since this
-# module doesn't have its own repo. Pass it as a config option instead:
-python_binary: python3
+iso_version: latest

--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -12,3 +12,6 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
+# iso_version derives the correct Python version from the ISO compatibility.json, avoiding
+# reliance on the Jenkins runner's default python3 binary.
+iso_version: latest

--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -12,6 +12,6 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
-# We can't rely on the generic module ci to find out the correct python binary since this
-# module doesn't have its own repo. Pass it as a config option instead:
-python_binary: python3
+# iso_version derives the correct Python version from the ISO compatibility.json, avoiding
+# reliance on the Jenkins runner's default python3 binary.
+iso_version: latest

--- a/lsm-testing/.ci-integration-tests.yml
+++ b/lsm-testing/.ci-integration-tests.yml
@@ -12,6 +12,6 @@ mypy_mode: fail
 # This module doesn't have its own repo, the module_path option ensures that the generic
 # module ci can still be used with it.
 module_path: lsm-testing
-# iso_version derives the correct Python version from the ISO compatibility.json, avoiding
-# reliance on the Jenkins runner's default python3 binary.
-iso_version: latest
+# We can't rely on the generic module ci to find out the correct python binary since this
+# module doesn't have its own repo. Pass it as a config option instead:
+python_binary: python3


### PR DESCRIPTION
This makes it use the python version compatible with the latest version of inmanta. The previous runs were selecting the latest dev version of inmanta-core so I assume the behaviour remains the same