### PR TITLE
Remove whitespace characters from version parameter

### DIFF
--- a/lsm-srlinux/ci/Jenkinsfile
+++ b/lsm-srlinux/ci/Jenkinsfile
@@ -63,6 +63,7 @@ def update_topology(String isoProductVersion) {
 * @param isoProductVersion: The version of the inmanta-service-orchestrator Python package of the orchestrator we are running against.
 */
 def convert_iso_version_to_docker_image_url(String isoProductVersion) {
+    isoProductVersion = isoProductVersion.replaceAll("\\s", "")
     def matcher = isoProductVersion =~ /(\d+)/
     // Is it a version number consisting of a single number
     if (matcher.matches()) {


### PR DESCRIPTION
I am not sure how, but two times in a row I managed to type in a version number with a trailing whitespace, which broke the version parsing logic. This PR makes sure we remove whitespace characters before parsing it.